### PR TITLE
Allows to call the `validate` method statically

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ $validator->validate('(function xss(x){evil()})');
 // returns `false`
 ```
 
+Or as a static method:
+
+```php
+\JsonpCallbackValidator::validate('JSONP.callback');
+// returns `true`
+
+\JsonpCallbackValidator::validate('(function xss(x){evil()})');
+// returns `false`
+```
 
 Installation
 ------------

--- a/src/JsonpCallbackValidator.php
+++ b/src/JsonpCallbackValidator.php
@@ -8,9 +8,9 @@
  */
 class JsonpCallbackValidator
 {
-    private $regexp = '/^[a-zA-Z_$][0-9a-zA-Z_$]*(?:\[(?:"(?:\\\.|[^"\\\])*"|\'(?:\\\.|[^\'\\\])*\'|\d+)\])*?$/';
+    private static $regexp = '/^[a-zA-Z_$][0-9a-zA-Z_$]*(?:\[(?:"(?:\\\.|[^"\\\])*"|\'(?:\\\.|[^\'\\\])*\'|\d+)\])*?$/';
 
-    private $reservedKeywords = array(
+    private static $reservedKeywords = array(
         'break',
         'do',
         'instanceof',
@@ -62,14 +62,14 @@ class JsonpCallbackValidator
      * @param  string  $callback
      * @return boolean
      */
-    public function validate($callback)
+    public static function validate($callback)
     {
         foreach (explode('.', $callback) as $identifier) {
-            if (!preg_match($this->regexp, $identifier)) {
+            if (!preg_match(self::$regexp, $identifier)) {
                 return false;
             }
 
-            if (in_array($identifier, $this->reservedKeywords)) {
+            if (in_array($identifier, self::$reservedKeywords)) {
                 return false;
             }
         }

--- a/tests/JsonpCallbackValidatorTest.php
+++ b/tests/JsonpCallbackValidatorTest.php
@@ -69,4 +69,9 @@ class JsonpCallbackValidatorTest extends \PHPUnit_Framework_TestCase
             array("array_of_functions['\'']",     self::IS_VALID),
         );
     }
+
+    public function testCallStatically()
+    {
+        $this->assertTrue(\JsonpCallbackValidator::validate('foo'));
+    }
 }


### PR DESCRIPTION
As the validator implementation might not vary, I find it cumbersome to have to instantiate an object for the validator.

In addition to being easier to write, this PR eliminates initialization of the same array several times if the validator is used several times.
