### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - 7.3
 
 matrix:
   include:
     - php: hhvm
       dist: trusty
+    - php: 5.3
+      dist: precise
+  allow_failures:
+    - php: hhvm
 
 before_script:
     - composer install --dev --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,16 @@
         "php": "^5.3 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5 || ^5.7"
+        "phpunit/phpunit": "^4.8 || ^5.7"
     },
     "autoload": {
-        "psr-0": { "JsonpCallbackValidator": "src/" }
+        "psr-0": {
+            "JsonpCallbackValidator": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "JsonpCallbackValidator\\Tests\\": "tests/"
+        }
     }
 }

--- a/tests/JsonpCallbackValidatorTest.php
+++ b/tests/JsonpCallbackValidatorTest.php
@@ -1,6 +1,11 @@
 <?php
 
-class JsonpCallbackValidatorTest extends \PHPUnit_Framework_TestCase
+namespace JsonpCallbackValidator\Tests;
+
+use JsonpCallbackValidator;
+use PHPUnit\Framework\TestCase;
+
+class JsonpCallbackValidatorTest extends TestCase
 {
     const IS_VALID   = true;
 
@@ -11,7 +16,7 @@ class JsonpCallbackValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidate($callback, $expected)
     {
-        $validator = new \JsonpCallbackValidator();
+        $validator = new JsonpCallbackValidator();
         $this->assertEquals($expected, $validator->validate($callback));
     }
 
@@ -72,6 +77,6 @@ class JsonpCallbackValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testCallStatically()
     {
-        $this->assertTrue(\JsonpCallbackValidator::validate('foo'));
+        $this->assertTrue(JsonpCallbackValidator::validate('foo'));
     }
 }


### PR DESCRIPTION
# Changed log
- Using the `psr-4` autoload because `psr-o` is deprecated.
- Using the PHPUnit namespace to be compatible with latest stable PHPUnit version.
- Let `hhvm` version be failed because it seems this version will be failed in Travis CI build.