### PR TITLE
Validate callback type

### DIFF
--- a/src/JsonpCallbackValidator.php
+++ b/src/JsonpCallbackValidator.php
@@ -66,7 +66,7 @@ class JsonpCallbackValidator
     {
         if (!is_string($callback)) {
             return false;
-	}
+        }
 
         foreach (explode('.', $callback) as $identifier) {
             if (!preg_match(self::$regexp, $identifier)) {

--- a/src/JsonpCallbackValidator.php
+++ b/src/JsonpCallbackValidator.php
@@ -64,6 +64,10 @@ class JsonpCallbackValidator
      */
     public static function validate($callback)
     {
+        if (!is_string($callback)) {
+            return false;
+	}
+
         foreach (explode('.', $callback) as $identifier) {
             if (!preg_match(self::$regexp, $identifier)) {
                 return false;

--- a/tests/JsonpCallbackValidatorTest.php
+++ b/tests/JsonpCallbackValidatorTest.php
@@ -69,6 +69,8 @@ class JsonpCallbackValidatorTest extends PHPUnitTestCase
             array("array_of_functions['k'ey'']",  self::IS_INVALID),
             array("array_of_functions[''']",      self::IS_INVALID),
             array("array_of_functions['\'']",     self::IS_VALID),
+            array([],                             self::IS_INVALID),
+            array(new \stdClass(),                self::IS_INVALID),
         );
     }
 


### PR DESCRIPTION
Hello,
I suggest we also validate the type of the callback.
PHP8 will throw a TypeError when one calls `explode()` for an array instead of a string.