### PR TITLE
Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.github export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/*.md export-ignore
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
Hi @willdurand

I noticed everything were downloaded when installing the library
<img width="240" alt="image" src="https://github.com/willdurand/JsonpCallbackValidator/assets/9052536/1f2dbdcd-4191-4b6f-8502-2ebd88ba6339">

When running compose install, things like ci config or tests folders shouldn't be downloaded.

The `export-ignore` syntax in the gitattributes file allow to avoid this.